### PR TITLE
better deps expansion and update_fields support

### DIFF
--- a/computedfields/graph.py
+++ b/computedfields/graph.py
@@ -524,6 +524,11 @@ class ComputedModelsGraph(Graph):
                                     or rel.related_query_name
                                     or rel.related_model._meta.model_name)
                         path_segments.append(symbol)
+                        # add path segment to self deps if we have an fk field on a CFM
+                        # this is needed to correctly propagate direct fk changes in local cf mro later on
+                        if isinstance(rel, ForeignKey) and cls in computed_models:
+                            self._check_concrete_field(cls, symbol)
+                            local_deps.setdefault(cls, {}).setdefault(field, set()).add(symbol)
                         cls = rel.related_model
                         fieldentry.setdefault(cls, []).append({'path': '__'.join(path_segments)})
                     # pop last path entry from '#' handling, since this it resolves to concrete fields

--- a/computedfields/graph.py
+++ b/computedfields/graph.py
@@ -523,20 +523,20 @@ class ComputedModelsGraph(Graph):
                             symbol = (rel.related_name
                                     or rel.related_query_name
                                     or rel.related_model._meta.model_name)
-                        path_segments.append(symbol)
                         # add path segment to self deps if we have an fk field on a CFM
                         # this is needed to correctly propagate direct fk changes in local cf mro later on
                         if isinstance(rel, ForeignKey) and cls in computed_models:
                             self._check_concrete_field(cls, symbol)
                             local_deps.setdefault(cls, {}).setdefault(field, set()).add(symbol)
+                        if path_segments:
+                            # add segment to intermodel graph deps
+                            # replaces the old '#' all rule with real source -> target deps
+                            fieldentry.setdefault(cls, []).append({'path': '__'.join(path_segments), 'depends': symbol})
+                        path_segments.append(symbol)
                         cls = rel.related_model
-                        fieldentry.setdefault(cls, []).append({'path': '__'.join(path_segments)})
-                    # pop last path entry from '#' handling, since this it resolves to concrete fields
-                    # FIXME: check - this might be wrong here, if the source model is part of a chain AND provides concrete fields?
-                    fieldentry[cls].pop()
                     for target_field in fieldnames:
                         self._check_concrete_field(cls, target_field)
-                        fieldentry[cls].append({'path': '__'.join(path_segments), 'depends': target_field})
+                        fieldentry.setdefault(cls, []).append({'path': '__'.join(path_segments), 'depends': target_field})
         return {'global': global_deps, 'local': local_deps}
 
     def _clean_data(self, data):
@@ -551,15 +551,7 @@ class ComputedModelsGraph(Graph):
                 for depmodel, relations in modeldata.items():
                     self.models[modelname(depmodel)] = depmodel
                     for dep in relations:
-                        # normally we refer to the given model field
-                        # if none is given, set it to '#' which assumes
-                        # any chance to the model should trigger the update
-                        # Note: '#' is only triggered for `.save` without
-                        # setting update_fields!
-                        # FIXME: with enforcing to list all fields '#' turns into plain relation listings
-                        # --> maybe simplify it to rel fieldnames?
-                        depends = dep.get('depends', '#')
-                        key = (modelname(depmodel), depends)
+                        key = (modelname(depmodel), dep['depends'])
                         value = (modelname(model), field)
                         cleaned.setdefault(key, set()).add(value)
         return cleaned

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -410,3 +410,19 @@ class ChainC(ComputedFieldsModel):
     @computed(models.CharField(max_length=32), depends=[['b', ['comp']]])
     def comp(self):
         return self.b.comp
+
+class ExpandA(models.Model):
+    name = models.CharField(max_length=32)
+
+class ExpandB(models.Model):
+    a = models.ForeignKey(ExpandA, on_delete=models.CASCADE)
+
+class ExpandC(models.Model):
+    b = models.ForeignKey(ExpandB, on_delete=models.CASCADE)
+
+class ExpandD(ComputedFieldsModel):
+    c = models.ForeignKey(ExpandC, on_delete=models.CASCADE)
+
+    @computed(models.CharField(max_length=32), depends=[['c.b.a', ['name']]])
+    def comp(self):
+        return self.c.b.a.name

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -400,7 +400,7 @@ class ChainA(ComputedFieldsModel):
 class ChainB(ComputedFieldsModel):
     a = models.ForeignKey(ChainA, on_delete=models.CASCADE)
 
-    @computed(models.CharField(max_length=32), depends=[['self', ['a']], ['a', ['name']]])
+    @computed(models.CharField(max_length=32), depends=[['a', ['name']]])
     def comp(self):
         return self.a.name
 

--- a/example/test_full/tests/test_chained.py
+++ b/example/test_full/tests/test_chained.py
@@ -14,7 +14,7 @@ class TestChained(TestCase):
         self.assertEqual(self.b.comp, 'a')
         self.assertEqual(self.c.comp, 'a')
 
-    def test_change_a(self):
+    def test_change_a_name(self):
         self.a.name = 'z'
         self.a.save(update_fields=['name'])
         self.b.refresh_from_db()
@@ -35,3 +35,36 @@ class TestChained(TestCase):
         self.c.refresh_from_db()
         self.assertEqual(self.b.comp, 'x')
         self.assertEqual(self.c.comp, 'x')
+
+
+class TestExpand(TestCase):
+    def setUp(self):
+        self.a = models.ExpandA.objects.create(name='a')
+        self.b = models.ExpandB.objects.create(a=self.a)
+        self.c = models.ExpandC.objects.create(b=self.b)
+        self.d = models.ExpandD.objects.create(c=self.c)
+
+    def test_init(self):
+        self.d.refresh_from_db()
+        self.assertEqual(self.d.comp, 'a')
+
+    def test_change_a_name(self):
+        self.a.name = 'z'
+        self.a.save(update_fields=['name'])
+        self.d.refresh_from_db()
+        self.assertEqual(self.d.comp, 'z')
+
+    def test_new_a(self):
+        new_a = models.ExpandA.objects.create(name='x')
+        self.b.a = new_a
+        self.b.save(update_fields=['a'])
+        self.d.refresh_from_db()
+        self.assertEqual(self.d.comp, 'x')
+
+    def test_new_b(self):
+        new_a = models.ExpandA.objects.create(name='x')
+        new_b = models.ExpandB.objects.create(a=new_a)
+        self.c.b = new_b
+        self.c.save(update_fields=['b'])
+        self.d.refresh_from_db()
+        self.assertEqual(self.d.comp, 'x')

--- a/example/test_full/tests/test_chained.py
+++ b/example/test_full/tests/test_chained.py
@@ -29,7 +29,7 @@ class TestChained(TestCase):
         #self.b.save()
         # also works
         #self.b.save(update_fields=['a', 'comp'])
-        # does not work without explicit listing 'a' under self deps
+        # expands automatically to 'comp' with commit 203b9bc
         self.b.save(update_fields=['a'])
         self.b.refresh_from_db()
         self.c.refresh_from_db()


### PR DESCRIPTION
Closes #27.

Changes made:
- intermodel graph now gets real src --> target deps for relational descent
- `#` placeholder as "all rule" removed from intermodel graph
- automatically add local fk fields to self deps on ComputedFieldsModels

With these changes it is not needed anymore to explicitly list relational descendents:
```python
@computed(Field(..), depends=[
    # only need this in declaration
    ['a.b.c', ['some_field']]

    # added internally from relational descent with
    # correct src --> target field association:
    ['a', ['b']],
    ['a.b', ['c']],
])
```
Now `update_fields` should correctly expand to dependent computed fields on local and foreign models.