### PR TITLE
better m2m handling

### DIFF
--- a/computedfields/graph.py
+++ b/computedfields/graph.py
@@ -441,6 +441,12 @@ class ComputedModelsGraph(Graph):
                     for symbol in path.split('.'):
                         try:
                             rel = cls._meta.get_field(symbol)
+                            if rel.many_to_many:
+                                # expand field deps by m2m relations - not sure about that one yet...
+                                path_segments.append(symbol)
+                                fieldentry.setdefault(rel.related_model, []).append(
+                                    {'path': '__'.join(path_segments), 'depends': rel.remote_field.name})
+                                path_segments.pop()
                         except FieldDoesNotExist:
                             # handle reverse relation (not a concrete field)
                             rel = getattr(cls, symbol).rel

--- a/computedfields/handlers.py
+++ b/computedfields/handlers.py
@@ -137,9 +137,8 @@ def m2m_handler(sender, instance, **kwargs):
     m2m actions.
 
     .. NOTE::
-        The handler triggers updates for both ends of the m2m
-        relation, which might lead to massive updates and thus
-        heavy time consuming database interaction.
+        The handler triggers updates for both ends of the m2m relation,
+        which might lead to massive database interaction.
     """
     fields = active_resolver._m2m.get(sender)
     # exit early if we have no update rule the through model

--- a/computedfields/handlers.py
+++ b/computedfields/handlers.py
@@ -10,9 +10,8 @@ in ``apps.ready``.
     commands ``makemigrations``, ``migrate`` and ``help``.
 """
 from threading import local
-from django.db.models.fields.reverse_related import ManyToManyRel
-from .resolver import active_resolver
 from django.db import transaction
+from .resolver import active_resolver
 
 
 # thread local storage to hold
@@ -102,24 +101,33 @@ def postdelete_handler(sender, instance, **kwargs):
     and updates them.
     """
     # after deletion we can update the associated computed fields
-    updates = DELETES.pop(instance, {})
-    for model, data in updates.items():
-        pks, fields = data
-        qs = model.objects.filter(pk__in=pks)
-        active_resolver.bulk_updater(qs, fields)
+    updates = DELETES.pop(instance, None)
+    if updates:
+        with transaction.atomic():
+            for model, [pks, fields] in updates.items():
+                active_resolver.bulk_updater(model.objects.filter(pk__in=pks), fields)
 
 
-def merge_pk_maps(mm1, mm2):
+def merge_pk_maps(obj1, obj2):
     """
-    Add mm2 onto mm1.
+    Merge pk map in `obj2` on `obj1`.
     """
-    for model, data in mm2.items():
+    for model, data in obj2.items():
         m2_pks, m2_fields = data
-        m1_pks, m1_fields = mm1.setdefault(model, [set(), set()])
+        m1_pks, m1_fields = obj1.setdefault(model, [set(), set()])
         m1_pks.update(m2_pks)
         m1_fields.update(m2_fields)
-    return mm1
+    return obj1
 
+def merge_qs_maps(obj1, obj2):
+    """
+    Merge queryset map in `obj2` on `obj1`.
+    """
+    for model, [qs2, fields2] in obj2.items():
+        query_field = obj1.setdefault(model, [model.objects.none(), set()])
+        query_field[0] |= qs2            # or'ed querysets
+        query_field[1].update(fields2)   # add fields
+    return obj1
 
 def m2m_handler(sender, instance, **kwargs):
     """
@@ -133,89 +141,63 @@ def m2m_handler(sender, instance, **kwargs):
         relation, which might lead to massive updates and thus
         heavy time consuming database interaction.
     """
+    fields = active_resolver._m2m.get(sender)
+    # exit early if we have no update rule the through model
+    if not fields:
+        return
+
     # since the graph does not handle the m2m through model
-    # we have to trigger updates for both ends
+    # we have to trigger updates for both ends (left and right side)
+    reverse = kwargs['reverse']
+    left = fields['right'] if reverse else fields['left']   # fieldname on instance
+    right = fields['left'] if reverse else fields['right']  # fieldname on model
     action = kwargs.get('action')
     model = kwargs['model']
 
     if action == 'post_add':
         pks = kwargs['pk_set']
-        # old code
-        #active_resolver.update_dependent_multi(
-        #    [instance, model.objects.filter(pk__in=pks)], update_local=False)
-
-        # new code
-        fields = active_resolver._graph.resolved['m2m'].get(sender)     # FIXME: m2m map needs correct resolver export
-        if fields:
-            reverse = kwargs['reverse']
-            left = fields['right'] if reverse else fields['left']
-            right = fields['left'] if reverse else fields['right']
-
-            u_left = active_resolver._querysets_for_update(type(instance), instance, update_fields=[left])
-            u_right = active_resolver._querysets_for_update(model, model.objects.filter(pk__in=pks), update_fields=[right])
-            final = {}
-            for updates in [u_left, u_right]:
-                for modell, data in updates.items():
-                    query_field = final.setdefault(modell, [modell.objects.none(), set()])
-                    query_field[0] |= data[0]       # or'ed querysets
-                    query_field[1].update(data[1])  # add fields
-            if final:
-                with transaction.atomic():
-                    for queryset, fields in final.values():
-                        active_resolver.bulk_updater(queryset, fields, False, False)
+        data = active_resolver._querysets_for_update(
+            type(instance), instance, update_fields=[left])
+        other = active_resolver._querysets_for_update(
+            model, model.objects.filter(pk__in=pks), update_fields=[right])
+        if other:
+            merge_qs_maps(data, other)
+        if data:
+            with transaction.atomic():
+                for queryset, fields in data.values():
+                    active_resolver.bulk_updater(queryset, fields)
 
     elif action == 'pre_remove':
-        # instance updates
-        data = active_resolver._querysets_for_update(
-            type(instance), instance, pk_list=True)
-        # other side updates
         pks = kwargs['pk_set']
+        data = active_resolver._querysets_for_update(
+            type(instance), instance, update_fields=[left], pk_list=True)
         other = active_resolver._querysets_for_update(
-            model, model.objects.filter(pk__in=pks), pk_list=True)
+            model, model.objects.filter(pk__in=pks), update_fields=[right], pk_list=True)
         if other:
             merge_pk_maps(data, other)
-        # final
         if data:
             M2M_REMOVE[instance] = data
 
     elif action == 'post_remove':
-        updates = M2M_REMOVE.pop(instance, {})
-        for model, data in updates.items():
-            pks, fields = data
-            qs = model.objects.filter(pk__in=pks)
-            active_resolver.bulk_updater(qs, fields)
+        updates = M2M_REMOVE.pop(instance, None)
+        if updates:
+            with transaction.atomic():
+                for _model, [pks, fields] in updates.items():
+                    active_resolver.bulk_updater(_model.objects.filter(pk__in=pks), fields)
 
     elif action == 'pre_clear':
-        # instance updates
-        data = active_resolver._querysets_for_update(type(instance), instance, pk_list=True)
-
-        # other side updates
-        # geez - have to get pks of other side ourself
-        inst_model = type(instance)
-        if kwargs['reverse']:
-            rel = list(filter(
-                lambda f: isinstance(f, ManyToManyRel) and f.through == sender,
-                inst_model._meta.get_fields()
-            ))[0]
-            other = active_resolver._querysets_for_update(
-                model, getattr(instance, rel.name).all(), pk_list=True)
-        else:
-            field = list(filter(
-                lambda f: isinstance(f, ManyToManyRel) and f.through == sender,
-                model._meta.get_fields()
-            ))[0]
-            other = active_resolver._querysets_for_update(
-                model, getattr(instance, field.remote_field.name).all(), pk_list=True)
+        data = active_resolver._querysets_for_update(
+            type(instance), instance, update_fields=[left], pk_list=True)
+        other = active_resolver._querysets_for_update(
+            model, getattr(instance, left).all(), update_fields=[right], pk_list=True)
         if other:
             merge_pk_maps(data, other)
-
-        # final
         if data:
             M2M_CLEAR[instance] = data
 
     elif action == 'post_clear':
-        updates = M2M_CLEAR.pop(instance, {})
-        for model, data in updates.items():
-            pks, fields = data
-            qs = model.objects.filter(pk__in=pks)
-            active_resolver.bulk_updater(qs, fields)
+        updates = M2M_CLEAR.pop(instance, None)
+        if updates:
+            with transaction.atomic():
+                for _model, [pks, fields] in updates.items():
+                    active_resolver.bulk_updater(_model.objects.filter(pk__in=pks), fields)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -238,6 +238,10 @@ in the example above.
     Note that because of this dependency expansion, it is not possible to omit foreign key
     relations on purpose, if they are part of a `depends` rule.
 
+    Further note, that a similar expansion is done for m2m and reverse m2m fields.
+    (Works similar to the fk expansion, but cannot be expressed in `depends`,
+    as m2m fields dont map directly to a source column in database terms.)
+
 
 Related Computed Fields
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -410,6 +410,8 @@ Changelog
 ---------
 
 - `master` - in preparation for  v0.1.0
+    - dependency expansion on M2M fields
+    - `m2m_changed` handler with filtering on m2m fields
     - remove custom metaclass, introducing `Resolver` class
     - new decorator `@precomputed` for custom save methods
     - remove old `depends` syntax

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -712,15 +712,12 @@ class FixtureChild(ComputedFieldsModel):
 class MGroup(models.Model):
     pass
 
-
 class MItem(models.Model):
     pass
-
 
 class MUser(models.Model):
     groups = models.ManyToManyField(MGroup, related_name="users")
     items = models.ManyToManyField(MItem, related_name="users")
-
 
 class MAgent(ComputedFieldsModel):
     user = models.OneToOneField(MUser, related_name="agent", on_delete=models.CASCADE)

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -706,3 +706,26 @@ class FixtureChild(ComputedFieldsModel):
     ])
     def path(self):
         return '/{}#{}/{}'.format(self.parent.name, self.parent.children_count, self.name)
+
+
+# better m2m support: #43
+class MGroup(models.Model):
+    pass
+
+
+class MItem(models.Model):
+    pass
+
+
+class MUser(models.Model):
+    groups = models.ManyToManyField(MGroup, related_name="users")
+    items = models.ManyToManyField(MItem, related_name="users")
+
+
+class MAgent(ComputedFieldsModel):
+    user = models.OneToOneField(MUser, related_name="agent", on_delete=models.CASCADE)
+
+    @computed(models.IntegerField(default=0), depends=[["user.items", ["id"]]])
+    def counter(self):
+        # This is used to detect when Agent gets updated
+        return self.counter + 1

--- a/example/test_full/tests/test_43.py
+++ b/example/test_full/tests/test_43.py
@@ -26,3 +26,9 @@ class TestBetterM2M(TestCase):
         self.agent.refresh_from_db()
         # should have touched Agent.counter once
         self.assertEqual(self.agent.counter, 2)
+
+    def test_add_user_to_item(self):
+        self.item.users.add(self.user)
+
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 2)

--- a/example/test_full/tests/test_43.py
+++ b/example/test_full/tests/test_43.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+from ..models import MAgent, MUser, MItem, MGroup
+
+
+class TestBetterM2M(TestCase):
+    def setUp(self):
+        self.group = MGroup.objects.create()
+        self.user = MUser.objects.create()
+        self.agent = MAgent.objects.create(user=self.user)
+        self.item = MItem.objects.create()
+
+    def test_init(self):
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 1)
+
+    def test_add_group_to_user(self):
+        self.user.groups.add(self.group)
+
+        self.agent.refresh_from_db()
+        # should not have touched Agent.counter
+        self.assertEqual(self.agent.counter, 1)
+
+    def test_add_item_to_user(self):
+        self.user.items.add(self.item)
+
+        self.agent.refresh_from_db()
+        # should have touched Agent.counter once
+        self.assertEqual(self.agent.counter, 2)

--- a/example/test_full/tests/test_43.py
+++ b/example/test_full/tests/test_43.py
@@ -15,20 +15,93 @@ class TestBetterM2M(TestCase):
 
     def test_add_group_to_user(self):
         self.user.groups.add(self.group)
-
         self.agent.refresh_from_db()
-        # should not have touched Agent.counter
-        self.assertEqual(self.agent.counter, 1)
+        self.assertEqual(self.agent.counter, 1)   # should not have touched Agent.counter
 
     def test_add_item_to_user(self):
         self.user.items.add(self.item)
-
         self.agent.refresh_from_db()
-        # should have touched Agent.counter once
-        self.assertEqual(self.agent.counter, 2)
+        self.assertEqual(self.agent.counter, 2)   # should have touched Agent.counter once
 
     def test_add_user_to_item(self):
         self.item.users.add(self.user)
-
         self.agent.refresh_from_db()
-        self.assertEqual(self.agent.counter, 2)
+        self.assertEqual(self.agent.counter, 2)   # should have touched Agent.counter once
+
+    def test_addremove_group_from_user(self):
+        g1 = MGroup.objects.create()
+        g2 = MGroup.objects.create()
+        self.user.groups.add(g1, g2)
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 1)
+
+        self.user.groups.remove(g1, g2)
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 1)
+
+    def test_clear_groups_from_user(self):
+        g1 = MGroup.objects.create()
+        g2 = MGroup.objects.create()
+        self.user.groups.add(g1, g2)
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 1)
+
+        self.user.groups.clear()
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 1)
+
+    def test_addremove_item_from_user(self):
+        i1 = MItem.objects.create()
+        i2 = MItem.objects.create()
+        self.user.items.add(i1, i2)
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 2)   # one touch
+
+        self.user.items.remove(i1, i2)
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 3)   # another touch
+
+    def test_clear_items_from_user(self):
+        i1 = MItem.objects.create()
+        i2 = MItem.objects.create()
+        self.user.items.add(i1, i2)
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 2)   # one touch
+
+        self.user.items.clear()
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.counter, 3)   # another touch
+
+    def test_addremove_user_from_item(self):
+        u1 = MUser.objects.create()
+        a1 = MAgent.objects.create(user=u1)
+        u2 = MUser.objects.create()
+        a2 = MAgent.objects.create(user=u2)
+        self.item.users.add(u1, u2)
+        a1.refresh_from_db()
+        a2.refresh_from_db()
+        self.assertEqual(a1.counter, 2)   # one touch
+        self.assertEqual(a1.counter, 2)   # one touch
+
+        self.item.users.remove(u1, u2)
+        a1.refresh_from_db()
+        a2.refresh_from_db()
+        self.assertEqual(a1.counter, 3)   # another touch
+        self.assertEqual(a1.counter, 3)   # another touch
+
+    def test_clear_users_from_item(self):
+        u1 = MUser.objects.create()
+        a1 = MAgent.objects.create(user=u1)
+        u2 = MUser.objects.create()
+        a2 = MAgent.objects.create(user=u2)
+        self.item.users.add(u1, u2)
+        a1.refresh_from_db()
+        a2.refresh_from_db()
+        self.assertEqual(a1.counter, 2)   # one touch
+        self.assertEqual(a1.counter, 2)   # one touch
+
+        self.item.users.clear()
+        a1.refresh_from_db()
+        a2.refresh_from_db()
+        self.assertEqual(a1.counter, 3)   # another touch
+        self.assertEqual(a1.counter, 3)   # another touch


### PR DESCRIPTION
Shall fix #43.

Introduces resolver field expansion on m2m fields, which can be used during `m2m_changed` signal for more fine grained update paths.