### PR TITLE
Multi table inheritance

### DIFF
--- a/computedfields/graph.py
+++ b/computedfields/graph.py
@@ -465,6 +465,7 @@ class ComputedModelsGraph(Graph):
                         except FieldDoesNotExist:
                             # handle reverse relation (not a concrete field)
                             descriptor = getattr(cls, symbol)
+                            # ReverseOneToOneDescriptor has a "related" attribute instead of "rel"
                             rel = getattr(descriptor, "rel", None) or getattr(descriptor, "related")
                             symbol = rel.related_name \
                                 or rel.related_query_name \

--- a/computedfields/graph.py
+++ b/computedfields/graph.py
@@ -464,7 +464,8 @@ class ComputedModelsGraph(Graph):
                                 path_segments.pop()
                         except FieldDoesNotExist:
                             # handle reverse relation (not a concrete field)
-                            rel = getattr(cls, symbol).rel
+                            descriptor = getattr(cls, symbol)
+                            rel = getattr(descriptor, "rel", None) or getattr(descriptor, "related")
                             symbol = rel.related_name \
                                 or rel.related_query_name \
                                 or rel.related_model._meta.model_name

--- a/computedfields/resolver.py
+++ b/computedfields/resolver.py
@@ -115,7 +115,7 @@ class Resolver:
         for model in self.models:
             fields = set()
             for field in model._meta.fields:
-                if field in self.computedfields:
+                if field.model == model and field in self.computedfields:
                     fields.add(field)
             if fields:
                 yield (model, fields)
@@ -265,10 +265,8 @@ class Resolver:
                                     self._m2m[rel.remote_field.through] = {
                                         'left': rel.name, 'right': rel.remote_field.name}
                         except FieldDoesNotExist:
-                            rel = getattr(cls, symbol).rel
-                            symbol = rel.related_name \
-                                or rel.related_query_name \
-                                or rel.related_model._meta.model_name
+                            descriptor = getattr(cls, symbol)
+                            rel = getattr(descriptor, "rel", None) or getattr(descriptor, "related")
                         cls = rel.related_model
 
     def _calc_modelhash(self):

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -346,6 +346,24 @@ class ConcreteWithForeignKey2(AbstractWithForeignKey):
         return self.target.d
 
 
+# Test classes for multi table inheritance support
+class ParentModel(ComputedFieldsModel):
+    @computed(models.CharField(max_length=255, null=True, blank=True), depends=[["childmodel", ["username"]], ["childmodel2", ["pseudo"]]])
+    def name(self):
+        if hasattr(self, "childmodel"):
+            return self.childmodel.username
+        elif hasattr(self, "childmodel2"):
+            return self.childmodel2.pseudo
+
+
+class ChildModel(ParentModel):
+    username = models.CharField(max_length=255)
+
+
+class ChildModel2(ParentModel):
+    pseudo = models.CharField(max_length=255)
+
+
 # test local field dependencies
 class SelfA(ComputedFieldsModel):
     name = models.CharField(max_length=32)

--- a/example/test_full/tests/test_multi_table_inheritance.py
+++ b/example/test_full/tests/test_multi_table_inheritance.py
@@ -3,7 +3,7 @@ from ..models import ChildModel, ChildModel2
 
 
 class MultiTableInheritanceModel(TestCase):
-    def test_computed_field_on_multi_table_inheritance_model(self):
+    def test_depends_on_child_model(self):
         child1 = ChildModel.objects.create(username="Child")
         child1.refresh_from_db()
         self.assertEqual(child1.name, "Child")
@@ -25,3 +25,44 @@ class MultiTableInheritanceModel(TestCase):
         child2.refresh_from_db()
 
         self.assertEqual(child2.name, "Kid")
+
+    def test_parent_depends_on_self(self):
+        child = ChildModel.objects.create(username="Child", x=12, y=67)
+        child.refresh_from_db()
+        self.assertEqual(child.name, "Child")
+        self.assertEqual(child.z, 12+67)
+
+        child.y = 8
+        child.save()
+
+        child.refresh_from_db()
+
+        self.assertEqual(child.z, 20)
+
+    def test_child_depends_on_self(self):
+        child = ChildModel.objects.create(username="Child", a=12, b=67)
+        child.refresh_from_db()
+        self.assertEqual(child.name, "Child")
+        self.assertEqual(child.c, 12+67)
+
+        child.b = 8
+        child.save()
+
+        child.refresh_from_db()
+
+        self.assertEqual(child.c, 20)
+
+    def test_child_depends_on_self_and_parent(self):
+        child = ChildModel2.objects.create(pseudo="Child", x=12, y=67)
+        child.refresh_from_db()
+        self.assertEqual(child.name, "Child")
+        self.assertEqual(child.z, 12+67)
+        self.assertEqual(child.other_name, "12Child79")
+
+        child.x = 10
+        child.save()
+
+        child.refresh_from_db()
+
+        self.assertEqual(child.z, 77)
+        self.assertEqual(child.other_name, "10Child77")

--- a/example/test_full/tests/test_multi_table_inheritance.py
+++ b/example/test_full/tests/test_multi_table_inheritance.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from ..models import ChildModel, ChildModel2
+
+
+class MultiTableInheritanceModel(TestCase):
+    def test_computed_field_on_multi_table_inheritance_model(self):
+        child1 = ChildModel.objects.create(username="Child")
+        child1.refresh_from_db()
+        self.assertEqual(child1.name, "Child")
+
+        child1.username = "Kid"
+        child1.save()
+
+        child1.refresh_from_db()
+
+        self.assertEqual(child1.name, "Kid")
+
+        child2 = ChildModel2.objects.create(pseudo="Pseudo")
+        child2.refresh_from_db()
+        self.assertEqual(child2.name, "Pseudo")
+
+        child2.pseudo = "Kid"
+        child2.save()
+
+        child2.refresh_from_db()
+
+        self.assertEqual(child2.name, "Kid")


### PR DESCRIPTION
@jerch This PR addresses Multi Table Inheritance, so it is now possible to have computed fields on a concrete parent model class.
Those fields may depend on fields on child classes, and child classes may have computed fields dependent on parent fields.

When writing those dependencies, one needs to consider the Parent and Child as if they were different models related by a One to One (which they are, under the hood). So the child will refer to its parent's field with `parent_ptr` instead of `self`, whereas the parent will refer to its child's field with `child`

I still need to add more tests, for instance to make sure it still works when directly manipulating Parent model instances, or when saving with `update_fields` but if you have a minute it'd be interesting to have your feedback about the general approach and whether you see any pitfall that could have escaped me.