### PR TITLE
correct handling of o2o reverse relations

### DIFF
--- a/computedfields/graph.py
+++ b/computedfields/graph.py
@@ -464,7 +464,8 @@ class ComputedModelsGraph(Graph):
                                 path_segments.pop()
                         except FieldDoesNotExist:
                             # handle reverse relation (not a concrete field)
-                            rel = getattr(cls, symbol).rel
+                            descriptor = getattr(cls, symbol)
+                            rel = getattr(descriptor, 'rel', None) or getattr(descriptor, 'related')
                             symbol = rel.related_name \
                                 or rel.related_query_name \
                                 or rel.related_model._meta.model_name

--- a/computedfields/resolver.py
+++ b/computedfields/resolver.py
@@ -265,10 +265,8 @@ class Resolver:
                                     self._m2m[rel.remote_field.through] = {
                                         'left': rel.name, 'right': rel.remote_field.name}
                         except FieldDoesNotExist:
-                            rel = getattr(cls, symbol).rel
-                            symbol = rel.related_name \
-                                or rel.related_query_name \
-                                or rel.related_model._meta.model_name
+                            descriptor = getattr(cls, symbol)
+                            rel = getattr(descriptor, 'rel', None) or getattr(descriptor, 'related')
                         cls = rel.related_model
 
     def _calc_modelhash(self):

--- a/example/test_full/tests/test_o2o_explicit.py
+++ b/example/test_full/tests/test_o2o_explicit.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from ..models import OBackward, OSource, ORelated, OForward
+
+
+class TestOne2OneExplicit(TestCase):
+    def setUp(self):
+        self.b = OBackward.objects.create(name='B')
+        self.s = OSource.objects.create(name='S', o=self.b)
+
+        self.r = ORelated.objects.create(name='R')
+        self.f = OForward.objects.create(name='F', o=self.r)
+
+    def test_init_backward(self):
+        self.b.refresh_from_db()
+        self.s.refresh_from_db()
+        self.assertEqual(self.b.forward_name, 'S')
+
+    def test_init_forward(self):
+        self.r.refresh_from_db()
+        self.f.refresh_from_db()
+        self.assertEqual(self.f.backward_name, 'R')
+
+    def test_rename_backward(self):
+        self.s.name = 'SS'
+        self.s.save(update_fields=['name'])
+        self.b.refresh_from_db()
+        self.assertEqual(self.b.forward_name, 'SS')
+
+    def test_rename_forward(self):
+        self.r.name = 'RR'
+        self.r.save(update_fields=['name'])
+        self.f.refresh_from_db()
+        self.assertEqual(self.f.backward_name, 'RR')


### PR DESCRIPTION
@mobiware 

Created this PR to fix the wrong attribute access for o2o back relations. Also found the reason, why it is not covered in the older test cases - the automatically created models have too many computed fields on them, thus the graph optimization still finds a valid update path around the missing symbol (while not being listed in depends). They are way too complex to grab the single relation case. Therefore I added 2 explicit models with tests only dealing with one case at a time.

This here is partially taken from your multi table PR, I think we should rebase that PR to keep it clean from bugfixing beside the inheritance part.