### PR TITLE
custom resolver signals

### DIFF
--- a/computedfields/helper.py
+++ b/computedfields/helper.py
@@ -8,7 +8,7 @@ def pairwise(iterable):
 
 
 def modelname(model):
-    return '%s.%s' % (model._meta.app_label, model._meta.verbose_name)
+    return '%s.%s' % (model._meta.app_label, model._meta.model_name)
 
 
 def is_sublist(needle, haystack):

--- a/computedfields/resolver.py
+++ b/computedfields/resolver.py
@@ -654,11 +654,9 @@ class Resolver:
             if collected_data is not None:
                 pks = set(el.pk for el in queryset)
                 # TODO: optimize signal_update flags on CFs into static map
-                # FIXME: filter for signal_update=True
-                if any(self._computed_models[model][f]._computed['signal_update'] for f in mro):
-                    collected_data \
-                        .setdefault(model, {}) \
-                        .setdefault(frozenset(mro), set()).update(pks)
+                signal_fields = frozenset(filter(lambda f: self._computed_models[model][f]._computed['signal_update'], mro))
+                if signal_fields:
+                    collected_data.setdefault(model, {}).setdefault(signal_fields, set()).update(pks)
             # trigger dependent comp field updates on all records
             # skip recursive call if queryset is empty
             if not local_only:

--- a/computedfields/signals.py
+++ b/computedfields/signals.py
@@ -1,3 +1,4 @@
 from django.dispatch import Signal
 
+state = Signal(providing_args=['state'])
 resolver_update_done = Signal(providing_args=['changeset', 'update_fields', 'data'])

--- a/computedfields/signals.py
+++ b/computedfields/signals.py
@@ -1,4 +1,65 @@
 from django.dispatch import Signal
 
-state = Signal(providing_args=['state'])
-resolver_update_done = Signal(providing_args=['changeset', 'update_fields', 'data'])
+#: Signal to indicate state changes of a resolver.
+#: The resolver operates in 3 states:
+#:
+#: - 'initial'
+#:    The initial state of the resolver for collecting models
+#:    and computed field definitions. Resolver maps and ``computed_models``
+#:    are not accessible yet.
+#: - 'models_loaded'
+#:    Second state of the resolver. Models and fields have been associated,
+#:    ``computed_models`` is accessible. In this state it is not possible
+#:    to add more models or fields. No resolver maps are loaded yet.
+#: - 'maps_loaded'
+#:    Third state of the resolver. The resolver is fully loaded and ready to go.
+#:    Resolver maps were either loaded from pickle file or created from
+#:    graph calculation.
+#:
+#: Arguments sent with this signal:
+#:
+#: - `sender`
+#:    Resolver instance, that changed the state.
+#: - `state`
+#:    One of the state strings above.
+#:
+#: .. NOTE::
+#:
+#:     The signal for the boot resolver at state ``'initial'`` cannot be caught by
+#:     a signal handler. For very early model/field setup work, inspect
+#:     ``resolver.state`` instead.
+state_changed = Signal(providing_args=['state'])
+
+#: Signal to indicate updates done by the dependency tree resolver.
+#:
+#: Arguments sent with this signal:
+#:
+#: - `sender`
+#:    Resolver instance, that was responsible for the updates.
+#: - `changeset`
+#:    Initial changeset, that triggered the computed field updates.
+#:    This is equivalent to the first argument of ``update_dependent`` (model instance or queryset).
+#: - `update_fields`
+#:    Fields marked as changed in the changeset. Equivalent to `update_fields` in
+#:    ``save(update_fields=...)`` or ``update_dependent(..., update_fields=...)``.
+#: - `data`
+#:    Mapping of models with instance updates of tracked computed fields.
+#:    Since the tracking of individual instance updates in the dependecy tree is quite expensive,
+#:    computed fields have to be enabled for update tracking by setting `signal_update=True`.
+#:
+#:    The returned mapping is in the form:
+#:
+#:    .. code-block:: python
+#:
+#:        {
+#:            modelA: {
+#:                        frozenset(updated_computedfields): set_of_affected_pks,
+#:                        frozenset(['comp1', 'comp2']): {1, 2, 3},
+#:                        frozenset(['comp2', 'compX']): {3, 45}
+#:                    },
+#:            modelB: {...}
+#:        }
+#:
+#:    Note that a single computed field might be contained in several update sets (thus you have
+#:    to aggregate further to pull all pks for a certain field update).
+post_update = Signal(providing_args=['changeset', 'update_fields', 'data'])

--- a/computedfields/signals.py
+++ b/computedfields/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+resolver_update_done = Signal(providing_args=['changeset', 'update_fields', 'data'])

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -38,3 +38,11 @@ admin.py
 .. automodule:: computedfields.admin
    :members:
    :show-inheritance:
+
+
+signals.py
+----------
+
+.. automodule:: computedfields.signals
+   :members:
+   :show-inheritance:

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -931,3 +931,20 @@ class Work(ComputedFieldsModel):
     ])
     def descriptive_assigment(self):
         return '"{}" is assigned to "{}"'.format(self.subject, self.user.fullname)
+
+
+# FIXME: quick hack to test aggregate signal from resolver, needs proper test cases
+from computedfields.signals import resolver_update_done
+import pprint
+
+def update_done_handler(sender, **kwargs):
+    changeset = kwargs.get('changeset')
+    update_fields = kwargs.get('update_fields')
+    data = kwargs.get('data')
+    pprint.pprint({
+        'changeset': changeset,
+        'update_fields': update_fields,
+        'data': data
+    })
+
+resolver_update_done.connect(update_done_handler)

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -943,3 +943,7 @@ class SignalChild(ComputedFieldsModel):
     @computed(models.CharField(max_length=32), depends=[['parent', ['name']]], signal_update=True)
     def parentname(self):
         return self.parent.name
+
+    @computed(models.CharField(max_length=32), depends=[['parent', ['name']]])  # field should not occur in signals
+    def parentname_no_signal(self):
+        return self.parent.name

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -933,18 +933,13 @@ class Work(ComputedFieldsModel):
         return '"{}" is assigned to "{}"'.format(self.subject, self.user.fullname)
 
 
-# FIXME: quick hack to test aggregate signal from resolver, needs proper test cases
-from computedfields.signals import resolver_update_done
-import pprint
+# signal test models
+class SignalParent(models.Model):
+    name = models.CharField(max_length=32)
 
-def update_done_handler(sender, **kwargs):
-    changeset = kwargs.get('changeset')
-    update_fields = kwargs.get('update_fields')
-    data = kwargs.get('data')
-    pprint.pprint({
-        'changeset': changeset,
-        'update_fields': update_fields,
-        'data': data
-    })
+class SignalChild(ComputedFieldsModel):
+    parent = models.ForeignKey(SignalParent, on_delete=models.CASCADE)
 
-resolver_update_done.connect(update_done_handler)
+    @computed(models.CharField(max_length=32), depends=[['parent', ['name']]], signal_update=True)
+    def parentname(self):
+        return self.parent.name

--- a/example/test_full/tests/test_signals.py
+++ b/example/test_full/tests/test_signals.py
@@ -1,0 +1,91 @@
+from django.test import TestCase
+from ..models import SignalParent, SignalChild
+from computedfields.signals import resolver_update_done
+from computedfields.models import update_dependent
+from contextlib import contextmanager
+
+@contextmanager
+def grab_signals(storage):
+    def simple_handler(sender, **kwargs):
+        changeset = kwargs.get('changeset')
+        update_fields = kwargs.get('update_fields')
+        data = kwargs.get('data')
+        storage.append({
+            'changeset': changeset,
+            'update_fields': update_fields,
+            'data': data
+        })
+    resolver_update_done.connect(simple_handler)
+    yield
+    resolver_update_done.disconnect(simple_handler)
+
+
+class TestSignals(TestCase):
+    def test_with_handler(self):
+        data = []
+        with grab_signals(data):
+
+            # creating parents should be silent
+            p1 = SignalParent.objects.create(name='p1')
+            p2 = SignalParent.objects.create(name='p2')
+            self.assertEqual(data, [])
+
+            # newly creating children should be silent as well
+            c1 = SignalChild.objects.create(parent=p1)
+            c2 = SignalChild.objects.create(parent=p2)
+            c3 = SignalChild.objects.create(parent=p2)
+            self.assertEqual(data, [])
+
+            # changing parent name should trigger signal with correct data
+            p1.name = 'P1'
+            p1.save()
+            self.assertEqual(data, [{
+                'changeset': p1,
+                'update_fields': None,
+                'data': {
+                  SignalChild: {frozenset(['parentname']): {c1.pk}}
+                }
+            }])
+            data.clear()
+
+            # update_fields should contain correct value
+            p2.name = 'P2'
+            p2.save(update_fields=['name'])
+            self.assertEqual(data, [{
+                'changeset': p2,
+                'update_fields': frozenset(['name']),
+                'data': {
+                  SignalChild: {frozenset(['parentname']): {c2.pk, c3.pk}}
+                }
+            }])
+            data.clear()
+
+            # values correctly updated
+            c1.refresh_from_db()
+            c2.refresh_from_db()
+            c3.refresh_from_db()
+            self.assertEqual(c1.parentname, 'P1')
+            self.assertEqual(c2.parentname, 'P2')
+            self.assertEqual(c3.parentname, 'P2')
+
+            # changes from bulk action
+            SignalParent.objects.filter(pk__in=[p2.pk]).update(name='P2_CHANGED')
+            qs = SignalParent.objects.filter(pk__in=[p2.pk])
+            update_dependent(qs, update_fields=['name'])
+            self.assertEqual(data, [{
+                'changeset': qs,
+                'update_fields': frozenset(['name']),
+                'data': {
+                  SignalChild: {frozenset(['parentname']): {c2.pk, c3.pk}}
+                }
+            }])
+            data.clear()
+
+            # values correctly updated
+            c1.refresh_from_db()
+            c2.refresh_from_db()
+            c3.refresh_from_db()
+            self.assertEqual(c1.parentname, 'P1')
+            self.assertEqual(c2.parentname, 'P2_CHANGED')
+            self.assertEqual(c3.parentname, 'P2_CHANGED')
+

--- a/example/test_full/tests/test_signals.py
+++ b/example/test_full/tests/test_signals.py
@@ -1,18 +1,17 @@
 from django.test import TestCase
 from ..models import SignalParent, SignalChild
-from computedfields.signals import resolver_update_done, state
+from computedfields.signals import post_update, state_changed
 from computedfields.models import update_dependent
 from contextlib import contextmanager
 from computedfields.resolver import Resolver
 
 @contextmanager
 def grab_state_signal(storage):
-    def handler(sender, **kwargs):
-        state = kwargs.get('state')
+    def handler(sender, state, **kwargs):
         storage.append({'sender': sender, 'state': state})
-    state.connect(handler)
+    state_changed.connect(handler)
     yield
-    state.disconnect(handler)
+    state_changed.disconnect(handler)
 
 
 class TestStateSignal(TestCase):
@@ -52,18 +51,15 @@ class TestStateSignal(TestCase):
 
 @contextmanager
 def grab_update_signal(storage):
-    def handler(sender, **kwargs):
-        changeset = kwargs.get('changeset')
-        update_fields = kwargs.get('update_fields')
-        data = kwargs.get('data')
+    def handler(sender, changeset, update_fields, data, **kwargs):
         storage.append({
             'changeset': changeset,
             'update_fields': update_fields,
             'data': data
         })
-    resolver_update_done.connect(handler)
+    post_update.connect(handler)
     yield
-    resolver_update_done.disconnect(handler)
+    post_update.disconnect(handler)
 
 
 class TestUpdateSignal(TestCase):


### PR DESCRIPTION
Shall fix #56.

This is just a proof of concept currently with hacked in signal dispatching for `update_dependent`.

TODO:
- apply data aggregation on all resolver parts including handler code
- find a good way to aggregate data with least mem usage / runtime penalty
- useful shaping of signal arguments
- single aggregation signal vs. more fine-grained ones or both

FYI: @mobiware 