### PR TITLE
Add code to remove django warning

### DIFF
--- a/computedfields/apps.py
+++ b/computedfields/apps.py
@@ -6,6 +6,7 @@ from .resolver import BOOT_RESOLVER
 
 class ComputedfieldsConfig(AppConfig):
     name = 'computedfields'
+    default_auto_field = 'django.db.models.AutoField'
 
     def __init__(self, *args, **kwargs):
         super(ComputedfieldsConfig, self).__init__(*args, **kwargs)


### PR DESCRIPTION
### Why is this change proposed?

I've got a recurring error on my server that is easily removed solely by adding this to the config file. It should be the default that the code already falls through to. The only difference is that by adding this to the config, the warning will no longer show up.