### PR TITLE
Update setup.cfg to fix  setuptools.errors.InvalidConfigError

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Fix build problems from  setuptools.errors.InvalidConfigError due to recent deprecation of 'description-file' in 'metadata' (setup.cfg) https://setuptools.pypa.io/en/stable/history.html#v78-0-0