### PR TITLE
fix related_name vs related_query_name issue

### DIFF
--- a/computedfields/graph.py
+++ b/computedfields/graph.py
@@ -557,9 +557,7 @@ class ComputedModelsGraph(Graph):
                             # handle reverse relation (not a concrete field)
                             descriptor = getattr(cls, symbol)
                             rel = getattr(descriptor, 'rel', None) or getattr(descriptor, 'related')
-                            symbol = rel.related_name \
-                                     or rel.related_query_name \
-                                     or rel.related_model._meta.model_name
+                            symbol = rel.field.related_query_name()
                             # add dependency to reverse relation field as well
                             # this needs to be added in opposite direction on related model
                             path_segments.append(symbol)

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -1107,3 +1107,18 @@ class HaTagProxy(HaTag):
 class HaProxy(Ha):
     class Meta:
         proxy = True
+
+
+# related_name vs. related_query_name issue #165
+class RNFoo(ComputedFieldsModel):
+    @computed(models.CharField(max_length=256), depends=[('bars', ['b'])])
+    def comp(self):
+        s = ''
+        if self.pk:
+            for bar in self.bars.all().order_by('pk'):
+                s += bar.b
+        return s
+
+class RNBar(models.Model):
+    b = models.CharField(max_length=10)
+    foo = models.ForeignKey(RNFoo, related_name='bars', related_query_name='bar', on_delete=models.CASCADE)

--- a/example/test_full/tests/test_165_related_query_name.py
+++ b/example/test_full/tests/test_165_related_query_name.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from ..models import RNBar, RNFoo
+
+
+class RelatedName(TestCase):
+    def setUp(self):
+        self.foo = RNFoo.objects.create()
+        self.bar = RNBar.objects.create(b='a', foo=self.foo)
+
+    def test_init(self):
+        self.foo.refresh_from_db()
+        self.assertEqual(self.foo.comp, 'a')
+    
+    def test_add_second(self):
+        bar = RNBar.objects.create(b='b', foo=self.foo)
+        self.foo.refresh_from_db()
+        self.assertEqual(self.foo.comp, 'ab')


### PR DESCRIPTION
Use `related_query_name()` method of the associated related field instead of accessing the name properties directly. Since the method pulls the names in a certain order, it should fix #165.