### PR TITLE
default_on_create argument

### DIFF
--- a/computedfields/graph.py
+++ b/computedfields/graph.py
@@ -36,6 +36,7 @@ class IComputedData(TypedDict):
     select_related: Sequence[str]
     prefetch_related: Sequence[Any]
     querysize: Optional[int]
+    default_on_create: Optional[bool]
 
 
 # django Field type extended by our _computed data attribute

--- a/computedfields/resolver.py
+++ b/computedfields/resolver.py
@@ -620,6 +620,9 @@ class Resolver:
         to the database, always use ``compute(fieldname)`` instead.
         """
         field = self._computed_models[model][fieldname]
+        if instance._state.adding or not instance.pk:
+            if field._computed['default_on_create']:
+                return field.get_default()
         return field._computed['func'](instance)
 
     def compute(self, instance: Model, fieldname: str) -> Any:
@@ -750,7 +753,8 @@ class Resolver:
         depends: Optional[IDepends] = None,
         select_related: Optional[Sequence[str]] = None,
         prefetch_related: Optional[Sequence[Any]] = None,
-        querysize: Optional[int] = None
+        querysize: Optional[int] = None,
+        default_on_create: Optional[bool] = False
     ) -> 'Field[_ST, _GT]':
         """
         Factory for computed fields.
@@ -791,7 +795,8 @@ class Resolver:
             'depends': depends or [],
             'select_related': select_related or [],
             'prefetch_related': prefetch_related or [],
-            'querysize': querysize
+            'querysize': querysize,
+            'default_on_create': default_on_create
         }
         cf.editable = False
         self.add_field(cf)
@@ -803,7 +808,8 @@ class Resolver:
         depends: Optional[IDepends] = None,
         select_related: Optional[Sequence[str]] = None,
         prefetch_related: Optional[Sequence[Any]] = None,
-        querysize: Optional[int] = None
+        querysize: Optional[int] = None,
+        default_on_create: Optional[bool] = False
     ) -> Callable[[Callable[..., _ST]], 'Field[_ST, _GT]']:
         """
         Decorator to create computed fields.
@@ -906,7 +912,8 @@ class Resolver:
                 depends=depends,
                 select_related=select_related,
                 prefetch_related=prefetch_related,
-                querysize=querysize
+                querysize=querysize,
+                default_on_create=default_on_create
             )
         return wrap
 

--- a/example/test_full/models.py
+++ b/example/test_full/models.py
@@ -1172,3 +1172,34 @@ class CFKRelatedData(ComputedFieldsModel):
     @computed(models.ForeignKey(CFKCatalogue2, on_delete=models.CASCADE))
     def c2(self):
         return self.parent.c2
+
+
+# default_on_create tests
+class DefaultParent(ComputedFieldsModel):
+    name = models.CharField(max_length=32)
+    children_names = ComputedField(
+        models.CharField(max_length=256, default='NOTHING'),
+        depends=[('children', ['name'])],
+        compute=lambda inst: ','.join(inst.children.all().values_list('name', flat=True)),
+        default_on_create=True
+    )
+
+class DefaultChild(ComputedFieldsModel):
+    name = models.CharField(max_length=32)
+    parent = models.ForeignKey(DefaultParent, related_name='children', on_delete=models.CASCADE)
+    toys = models.ManyToManyField('DefaultToy', related_name='children')
+    toy_names = ComputedField(
+        models.CharField(max_length=256, default=lambda:'NO TOYS, SAD'),
+        depends=[('toys', ['name'])],
+        compute=lambda inst: ','.join(inst.toys.all().values_list('name', flat=True)),
+        default_on_create=True
+    )
+
+class DefaultToy(ComputedFieldsModel):
+    name = models.CharField(max_length=32)
+    children_names = ComputedField(
+        models.CharField(max_length=256, default='no one wants to play with this'),
+        depends=[('children', ['name'])],
+        compute=lambda inst: ','.join(inst.children.all().values_list('name', flat=True)),
+        default_on_create=True
+    )

--- a/example/test_full/tests/test_default_on_create.py
+++ b/example/test_full/tests/test_default_on_create.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+from .. import models
+
+
+class DefaultOnCreate(TestCase):
+    def setUp(self):
+        self.p1 = models.DefaultParent.objects.create(name='P1')
+        self.p2 = models.DefaultParent.objects.create(name='P2')
+        self.c1 = models.DefaultChild.objects.create(name='C1', parent=self.p1)
+        self.c11 = models.DefaultChild.objects.create(name='C11', parent=self.p1)
+        self.t1 = models.DefaultToy.objects.create(name='T1')
+        self.t2 = models.DefaultToy.objects.create(name='T2')
+        self.c1.toys.add(self.t1)
+      
+    def test_created_fk(self):
+        self.p1.refresh_from_db()
+        self.p2.refresh_from_db()
+        self.assertEqual(self.p1.children_names, 'C1,C11')
+        self.assertEqual(self.p2.children_names, 'NOTHING')
+
+    def test_created_m2m(self):
+        self.c1.refresh_from_db()
+        self.c11.refresh_from_db()
+        self.assertEqual(self.c1.toy_names, 'T1')
+        self.assertEqual(self.c11.toy_names, 'NO TOYS, SAD')
+
+    def test_created_m2m_back(self):
+        self.t1.refresh_from_db()
+        self.t2.refresh_from_db()
+        self.assertEqual(self.t1.children_names, 'C1')
+        self.assertEqual(self.t2.children_names, 'no one wants to play with this')
+
+    def test_copyclone_fk(self):
+        self.p1.refresh_from_db()
+        self.assertEqual(self.p1.children_names, 'C1,C11')
+        self.p1.pk = None
+        self.p1.save()
+        self.assertEqual(self.p1.children_names, 'NOTHING')
+
+    def test_copyclone_m2m(self):
+        self.c1.refresh_from_db()
+        self.assertEqual(self.c1.toy_names, 'T1')
+        self.c1.pk = None
+        self.c1.save()
+        self.assertEqual(list(self.c1.toys.all()), [])
+        self.assertEqual(self.c1.toy_names, 'NO TOYS, SAD')
+
+    def test_copyclone_m2m_back(self):
+        self.t1.refresh_from_db()
+        self.assertEqual(self.t1.children_names, 'C1')
+        self.t1.pk = None
+        self.t1.save()
+        self.assertEqual(list(self.t1.children.all()), [])
+        self.assertEqual(self.t1.children_names, 'no one wants to play with this')


### PR DESCRIPTION
This PR implements the idea from #157 as argument _default_on_create_ on `@computed` and `ComputedField`.

**Behavior:**
When set to true for a CF, its value will be pulled from the fields _default_ argument for newly created or copycloned instances. In that case the compute function will not be touched at all.

To follow the least surprise principle the argument defaults to `False` sticking to the current behavior.


Fixes #157.