### PR TITLE
signals

### DIFF
--- a/computedfields/resolver.py
+++ b/computedfields/resolver.py
@@ -606,7 +606,7 @@ class Resolver:
                 self._update(model._base_manager.all(), change, fields)
 
             if pks:
-                resolver_update.send(sender=self, model=model, fields=fields, pk_set=pks)
+                resolver_update.send(sender=self, model=model, fields=fields, pks=pks)
 
         # trigger dependent comp field updates from changed records
         # other than before we exit the update tree early, if we have no changes at all

--- a/computedfields/signals.py
+++ b/computedfields/signals.py
@@ -1,0 +1,40 @@
+from django.dispatch import Signal
+
+
+# Signal sent upon start of the resolver. `sender` points to the resolver instance.
+resolver_start = Signal()
+"""Signal sent upon start of the resolver. `sender` points to the resolver instance."""
+
+
+# Signal sent after a bulk update by the resolver.
+resolver_update = Signal()
+"""
+Signal sent after a bulk update by the resolver.
+
+Arguments sent with this signal:
+
+- `sender`
+    Resolver instance responsible for the updates.
+- `model`
+    The model class.
+- `fields`
+    Set of computed field names, that were updated.
+- `pks`
+    List of model instance pks, that were updated.
+
+    
+Note that this signal is sent immediately after the bulk update within the whole
+(recursive) dependency tree update done by the resolver. Furthermore your handler
+will be called under the update's transaction umbrella.
+
+To not disrupt the resolver's tree update, you must avoid any raising code pattern
+in your handler code. Database interactions should be avoided, as the state is not
+fully resynced yet.
+
+Also refer to the manual on how to use this signal in a safe way.
+"""
+
+
+# Signal sent upon exit of the resolver. `sender` points to the resolver instance.
+resolver_exit = Signal()
+"""Signal sent upon exit of the resolver. `sender` points to the resolver instance."""

--- a/computedfields/signals.py
+++ b/computedfields/signals.py
@@ -3,13 +3,13 @@ from django.dispatch import Signal
 
 # Signal sent upon start of the resolver. `sender` points to the resolver instance.
 resolver_start = Signal()
-"""Signal sent upon start of the resolver. `sender` points to the resolver instance."""
+"""Signal sent upon start of a tree update. `sender` points to the resolver instance."""
 
 
 # Signal sent after a bulk update by the resolver.
 resolver_update = Signal()
 """
-Signal sent after a bulk update by the resolver.
+Signal sent after a bulk update on a model.
 
 Arguments sent with this signal:
 
@@ -37,4 +37,4 @@ Also refer to the manual on how to use this signal in a safe way.
 
 # Signal sent upon exit of the resolver. `sender` points to the resolver instance.
 resolver_exit = Signal()
-"""Signal sent upon exit of the resolver. `sender` points to the resolver instance."""
+"""Signal sent upon exit of a tree update. `sender` points to the resolver instance."""

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -425,6 +425,53 @@ we could listen to. You have 2 options to work around this issue:
         update_dependent(Entry.objects.filter(pk__in=pks), update_fields=['blog'], old=old)
 
 
+Signals
+-------
+
+Version 0.3.0 introduced 3 custom signals sent by the resolver:
+
+- `resolver_start` indicates the start of a resolver update
+- `resolver_update` sent immediately after a model's bulk update
+- `resolver_exit` indicates the exit of a resolver update
+
+The interesting signal is `resolver_update`, as it allows you to introspect,
+which computed fields on which records were updated. But since that signal is sent right away from deep within
+of the resolver's tree update, it comes with a few caveats:
+
+- still in resolver DFS recursion
+- database not fully resynced yet
+- still under the resolver's transaction umbrella
+
+
+.. WARNING::
+
+    To not compromise the resolver's DFS update, you should not use any complicated or likely-to-raise code
+    in your `resolver_update` handler. Also database interactions, especially calls to `update_dependent`
+    should be avoided.
+
+Instead collect the interesting data points and wait for the `resolver_exit` signal.
+After that you can safely do your processing, example:
+
+.. CODE:: python
+
+    from computedfields.signals import resolver_update, resolver_exit
+
+    def collect_updates(sender, model, fields, pks):
+        # filter for updates of ModelXY.comp
+        if model == ModelXY and 'comp' in fields:
+            # only collect updated pks here
+            store_somewhere(pks)
+    resolver_update.connect(collect_updates)
+
+    def on_resolver_exit(sender):
+        # retrieve updated pks for ModelXY.comp
+        pks = retrieve_again()
+        # here it is safe to do all nasty things
+        # without compromising the resolver update
+        likely_to_fail(ModelXY.objects.filter(pk__pks))
+    resolver_exit.connect(on_resolver_exit)
+
+
 f-expressions
 -------------
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -446,7 +446,7 @@ of the resolver's tree update, it comes with a few caveats:
 .. WARNING::
 
     To not compromise the resolver's DFS update, you should not use any complicated or likely-to-raise code
-    in your `resolver_update` handler. Also database interactions, especially calls to `update_dependent`
+    in your `resolver_update` handler. Also database interactions, especially calls to `update_dependent`,
     should be avoided.
 
 Instead collect the interesting data points and wait for the `resolver_exit` signal.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -38,3 +38,11 @@ admin.py
 .. automodule:: computedfields.admin
    :members:
    :show-inheritance:
+
+
+signals.py
+----------
+
+.. automodule:: computedfields.signals
+   :members:
+   :show-inheritance:

--- a/example/test_full/tests/test_signals.py
+++ b/example/test_full/tests/test_signals.py
@@ -1,0 +1,364 @@
+from django.test import TestCase
+from ..models import DefaultParent, DefaultChild, DefaultToy
+from computedfields.signals import resolver_start, resolver_exit, resolver_update
+
+
+RECORDED = []
+
+
+def record_start(sender, **kwargs):
+    RECORDED.append(['start'])
+
+def record_exit(sender, **kwargs):
+    RECORDED.append(['exit'])
+
+def record_update(sender, model, fields, pks, **kwargs):
+    RECORDED.append(['update', model, fields, pks])
+
+
+class Signals(TestCase):
+    def setUp(self) -> None:
+        self.p1 = DefaultParent.objects.create(name='p1')
+        self.p2 = DefaultParent.objects.create(name='p2')
+        self.c1 = DefaultChild.objects.create(name='c1', parent=self.p1)
+        self.c2 = DefaultChild.objects.create(name='c2', parent=self.p1)
+        self.t1 = DefaultToy.objects.create(name='t1')
+        self.t2 = DefaultToy.objects.create(name='t2')
+        self.c1.toys.add(self.t1)
+
+        resolver_start.connect(record_start)
+        resolver_exit.connect(record_exit)
+        resolver_update.connect(record_update)
+        return super().setUp()
+    
+    def tearDown(self) -> None:
+        resolver_start.disconnect(record_start)
+        resolver_exit.disconnect(record_exit)
+        resolver_update.disconnect(record_update)
+        return super().tearDown()
+
+    def test_create_parent(self):
+        RECORDED.clear()
+        # creating a parent should not trigger send any signal, as nothing depends on it
+        DefaultParent.objects.create(name='some_p')
+        p = DefaultParent(name='some_p')
+        p.save()
+        self.assertEqual(RECORDED, [])
+
+    def test_create_child(self):
+        RECORDED.clear()
+        # create child must update DefaultParent.children_names
+        DefaultChild.objects.create(name='some_c', parent=self.p1)
+        self.assertEqual(RECORDED, [
+            ['start'],
+            ['update', DefaultParent, {'children_names'}, [self.p1.pk]],
+            ['exit']
+        ])
+        RECORDED.clear()
+        c = DefaultChild(name='some_c', parent=self.p1)
+        c.save()
+        self.assertEqual(RECORDED, [
+            ['start'],
+            ['update', DefaultParent, {'children_names'}, [self.p1.pk]],
+            ['exit']
+        ])
+        RECORDED.clear()
+
+    def test_create_toy(self):
+        RECORDED.clear()
+        # create toy updates DefaultChild.toy_names
+        # but since it is not linked to a child, resolver exits empty
+        DefaultToy.objects.create(name='some_t')
+        t = DefaultToy(name='some_t')
+        t.save()
+        self.assertEqual(RECORDED, [['start'], ['exit'], ['start'], ['exit']])
+        RECORDED.clear()
+
+    def test_delete_parent(self):
+        RECORDED.clear()
+        # delete parent w'o child does nothing
+        self.p2.delete()
+        self.assertEqual(RECORDED, [])
+
+        # delete parent with child updates:
+        # - first cascade delete p1 --> c1,c2
+        # - delete c1,c2 updates DefaultParent.children_name and DefaultToy.children_names
+        # - delete p1
+        self.p1.delete()
+        self.assertEqual(RECORDED, [
+            ['start'],
+            ['update', DefaultParent, {'children_names'}, [1]],
+            ['exit'],
+            ['start'],  # FIXME: why second run here?
+            ['update', DefaultToy, {'children_names'}, [1]],
+            ['exit'],
+        ])
+        RECORDED.clear()
+
+    def test_delete_child(self):
+        RECORDED.clear()
+        # delete child updates DefaultParent.children_names
+        self.c2.delete()
+        self.assertEqual(RECORDED, [
+            ['start'],
+            ['update', DefaultParent, {'children_names'}, [self.p1.pk]],
+            ['exit']
+        ])
+        RECORDED.clear()
+
+        # delete child with toys updates DefaultParent.children_name and DefaultToy.children_names
+        self.c1.delete()
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [1]], # updates may flip positions
+                ['update', DefaultParent, {'children_names'}, [self.p1.pk]],
+                ['exit'],
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultParent, {'children_names'}, [self.p1.pk]],
+                ['update', DefaultToy, {'children_names'}, [1]],
+                ['exit'],
+            ])
+        RECORDED.clear()
+
+    def test_delete_toy(self):
+        RECORDED.clear()
+        # empty, if not linked to child
+        self.t2.delete()
+        self.assertEqual(RECORDED, [])
+
+        # linked to child updates DefaultChild.toy_names
+        self.t1.delete()
+        self.assertEqual(RECORDED, [
+            ['start'],
+            ['update', DefaultChild, {'toy_names'}, [self.c1.pk]],
+            ['exit']
+        ])
+        RECORDED.clear()
+
+    def test_save_details(self):
+        RECORDED.clear()
+        # a full save trigger start/end, if something depends on a field
+        self.c1.save()
+        self.assertEqual(RECORDED, [['start'], ['exit']])
+        RECORDED.clear()
+
+        # partial save of non-depends fields does not trigger any signal
+        self.c1.save(update_fields=['toy_names'])
+        self.assertEqual(RECORDED, [])
+
+        RECORDED.clear()
+
+    def test_move_child_parent(self):
+        RECORDED.clear()
+        # move c1 --> p1 (no change) is an empty update
+        self.c1.parent = self.p1
+        self.c1.save()
+        self.assertEqual(RECORDED, [['start'], ['exit']])
+        RECORDED.clear()
+
+        # move c2 --> p2 updates DefaultParent.children_names on p2 & p1
+        self.c2.parent = self.p2
+        self.c2.save()
+        self.assertEqual(RECORDED, [
+            ['start'],
+            ['update', DefaultParent, {'children_names'}, [self.p2.pk]],
+            ['update', DefaultParent, {'children_names'}, [self.p1.pk]],
+            ['exit']
+        ])
+        RECORDED.clear()
+
+    def test_m2m_child_toy(self):
+        RECORDED.clear()
+        # add t2 to c2 updates DefaultChild.toy_names & DefaultToy.children_names
+        self.c2.toys.add(self.t2)
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()
+
+        # remove t2 from c2 updates DefaultChild.toy_names & DefaultToy.children_names
+        self.c2.toys.remove(self.t2)
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()
+
+        # empty clear trigger nothing
+        self.c2.toys.clear()
+        self.assertEqual(RECORDED, [])
+
+        # non-empty clear updates DefaultChild.toy_names & DefaultToy.children_names
+        self.c1.toys.clear()
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()
+
+        # set to empty updates DefaultChild.toy_names & DefaultToy.children_names
+        self.c1.toys.set([self.t1, self.t2])
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk, self.t2.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk, self.t2.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()
+
+        # set to non-empty updates DefaultChild.toy_names & DefaultToy.children_names on all 4 ends
+        self.c2.toys.set([self.t1, self.t2])
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk, self.t2.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk, self.t2.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()
+
+    def test_m2m_child_toy_reverse(self):
+        RECORDED.clear()
+        # add t2 to c2 updates DefaultChild.toy_names & DefaultToy.children_names
+        self.t2.children.add(self.c2)
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()
+
+        # remove t2 from c2 updates DefaultChild.toy_names & DefaultToy.children_names
+        self.t2.children.remove(self.c2)
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c2.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()
+
+        # empty clear trigger nothing
+        self.t2.children.clear()
+        self.assertEqual(RECORDED, [])
+
+        # non-empty clear updates DefaultChild.toy_names & DefaultToy.children_names
+        self.t1.children.clear()
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()
+
+        # set to empty updates DefaultChild.toy_names & DefaultToy.children_names
+        self.t1.children.set([self.c1, self.c2])
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk, self.c2.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t1.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk, self.c2.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()
+
+        # set to non-empty updates DefaultChild.toy_names & DefaultToy.children_names on all 4 ends
+        self.t2.children.set([self.c1, self.c2])
+        try:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk, self.c2.pk]],  # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['exit']
+            ])
+        except AssertionError:
+            self.assertEqual(RECORDED, [
+                ['start'],
+                ['update', DefaultToy, {'children_names'}, [self.t2.pk]],
+                ['update', DefaultChild, {'toy_names'}, [self.c1.pk, self.c2.pk]],
+                ['exit']
+            ])
+        RECORDED.clear()

--- a/example/test_full/tests/test_signals.py
+++ b/example/test_full/tests/test_signals.py
@@ -84,13 +84,14 @@ class Signals(TestCase):
         # - first cascade delete p1 --> c1,c2
         # - delete c1,c2 updates DefaultParent.children_name and DefaultToy.children_names
         # - delete p1
+        pk = self.p1.pk
         self.p1.delete()
         self.assertEqual(RECORDED, [
             ['start'],
-            ['update', DefaultParent, {'children_names'}, [1]],
+            ['update', DefaultParent, {'children_names'}, [pk]],
             ['exit'],
             ['start'],  # FIXME: why second run here?
-            ['update', DefaultToy, {'children_names'}, [1]],
+            ['update', DefaultToy, {'children_names'}, [pk]],
             ['exit'],
         ])
         RECORDED.clear()
@@ -107,11 +108,12 @@ class Signals(TestCase):
         RECORDED.clear()
 
         # delete child with toys updates DefaultParent.children_name and DefaultToy.children_names
+        child_pk = self.c1.pk
         self.c1.delete()
         try:
             self.assertEqual(RECORDED, [
                 ['start'],
-                ['update', DefaultToy, {'children_names'}, [1]], # updates may flip positions
+                ['update', DefaultToy, {'children_names'}, [child_pk]], # updates may flip positions
                 ['update', DefaultParent, {'children_names'}, [self.p1.pk]],
                 ['exit'],
             ])
@@ -119,7 +121,7 @@ class Signals(TestCase):
             self.assertEqual(RECORDED, [
                 ['start'],
                 ['update', DefaultParent, {'children_names'}, [self.p1.pk]],
-                ['update', DefaultToy, {'children_names'}, [1]],
+                ['update', DefaultToy, {'children_names'}, [child_pk]],
                 ['exit'],
             ])
         RECORDED.clear()


### PR DESCRIPTION
Second approach to a signal implementation, this time much more light-weight with only 3 simple signals:

- `resolver_start` to indicate the start of a resolver update
- `resolver_update` sent immediately after a model bulk update
- `resolver_exit` to indicate the exit of a resolver update

This lighter implementation exposes the `resolver_update` signals directly from the ongoing dependency tree update, which has several downsides, like being under a transaction and the state not being fully in sync again. --> Needs proper documentation of the shortcomings.

TODO:
- [x] place start & exit signals on handlers (blocked by #177 and #179)
- [x] test cases
- [x] docs in the manual

Fixes #56 finally.