### PR TITLE
fix de-optimization by union skipping select/prefetch_related

### DIFF
--- a/example/test_full/tests/test_union_related_settings.py
+++ b/example/test_full/tests/test_union_related_settings.py
@@ -46,8 +46,8 @@ class UnionRelatedPerf(TestCase):
         pr = time() - start
         self.assertEqual(UPerson.objects.filter(address='App #888, Celestial Border').count(), PERSONS+1)
 
-        self.assertLess(sr*5, plain)
-        self.assertLess(pr*5, plain)
+        self.assertLess(sr, plain)
+        self.assertLess(pr, plain)
 
         UPerson._meta.get_field('address')._computed['select_related'] = []
         UPerson._meta.get_field('address')._computed['prefetch_related'] = []
@@ -96,8 +96,8 @@ class UnionRelatedPerfNC(TestCase):
         pr = time() - start
         self.assertEqual(UPerson.objects.filter(address='App #888, Celestial Border').count(), PERSONS+1)
 
-        self.assertLess(sr*5, plain)
-        self.assertLess(pr*5, plain)
+        self.assertLess(sr, plain)
+        self.assertLess(pr, plain)
 
         UPerson._meta.get_field('address')._computed['select_related'] = []
         UPerson._meta.get_field('address')._computed['prefetch_related'] = []

--- a/example/test_full/tests/test_union_related_settings.py
+++ b/example/test_full/tests/test_union_related_settings.py
@@ -1,0 +1,103 @@
+from django.test import TestCase
+from ..models import UAppartment, UPerson
+from computedfields.models import update_dependent
+from django.db.transaction import atomic
+from time import time
+
+
+PERSONS = 100
+
+class UnionRelatedPerf(TestCase):
+    def setUp(self):
+        with atomic():
+            self.a = UAppartment.objects.create(street='Abyss Road', number=5)
+            self.p = UPerson.objects.create(appartment=self.a)
+            for _ in range(PERSONS):
+                UPerson.objects.create(parent=self.p, at_parent=True)
+    
+    def test_rename_appartment_perf(self):
+        start = time()
+        with atomic():
+            self.a.street = 'Hellway'
+            self.a.number = 666
+            self.a.save()
+        plain = time() - start
+        self.assertEqual(UPerson.objects.filter(address='App #666, Hellway').count(), PERSONS+1)
+        
+        # patch select_related
+        UPerson._meta.get_field('address')._computed['select_related'] = ['appartment', 'parent__appartment']
+        UPerson._meta.get_field('address')._computed['prefetch_related'] = []
+        start = time()
+        with atomic():
+            self.a.street = 'Heaven Lane'
+            self.a.number = 777
+            self.a.save()
+        sr = time() - start
+        self.assertEqual(UPerson.objects.filter(address='App #777, Heaven Lane').count(), PERSONS+1)
+
+        # patch prefetch_related
+        UPerson._meta.get_field('address')._computed['select_related'] = []
+        UPerson._meta.get_field('address')._computed['prefetch_related'] = ['appartment', 'parent__appartment']
+        start = time()
+        with atomic():
+            self.a.street = 'Celestial Border'
+            self.a.number = 888
+            self.a.save()
+        pr = time() - start
+        self.assertEqual(UPerson.objects.filter(address='App #888, Celestial Border').count(), PERSONS+1)
+
+        self.assertLess(sr*5, plain)
+        self.assertLess(pr*5, plain)
+
+        UPerson._meta.get_field('address')._computed['select_related'] = []
+        UPerson._meta.get_field('address')._computed['prefetch_related'] = []
+
+
+
+
+
+from computedfields.models import not_computed
+class UnionRelatedPerfNC(TestCase):
+    def setUp(self):
+        with atomic() and not_computed(recover=True):
+            self.a = UAppartment.objects.create(street='Abyss Road', number=5)
+            self.p = UPerson.objects.create(appartment=self.a)
+            for _ in range(PERSONS):
+                UPerson.objects.create(parent=self.p, at_parent=True)
+    
+    def test_rename_appartment_perf(self):
+        start = time()
+        with atomic() and not_computed(recover=True):
+            self.a.street = 'Hellway'
+            self.a.number = 666
+            self.a.save()
+        plain = time() - start
+        self.assertEqual(UPerson.objects.filter(address='App #666, Hellway').count(), PERSONS+1)
+        
+        # patch select_related
+        UPerson._meta.get_field('address')._computed['select_related'] = ['appartment', 'parent__appartment']
+        UPerson._meta.get_field('address')._computed['prefetch_related'] = []
+        start = time()
+        with atomic() and not_computed(recover=True):
+            self.a.street = 'Heaven Lane'
+            self.a.number = 777
+            self.a.save()
+        sr = time() - start
+        self.assertEqual(UPerson.objects.filter(address='App #777, Heaven Lane').count(), PERSONS+1)
+
+        # patch prefetch_related
+        UPerson._meta.get_field('address')._computed['select_related'] = []
+        UPerson._meta.get_field('address')._computed['prefetch_related'] = ['appartment', 'parent__appartment']
+        start = time()
+        with atomic() and not_computed(recover=True):
+            self.a.street = 'Celestial Border'
+            self.a.number = 888
+            self.a.save()
+        pr = time() - start
+        self.assertEqual(UPerson.objects.filter(address='App #888, Celestial Border').count(), PERSONS+1)
+
+        self.assertLess(sr*5, plain)
+        self.assertLess(pr*5, plain)
+
+        UPerson._meta.get_field('address')._computed['select_related'] = []
+        UPerson._meta.get_field('address')._computed['prefetch_related'] = []


### PR DESCRIPTION
Reverts the de-optimization of skipping _select_related_ or _prefetch_related_ on UNIONed querysets. 

The work-around is to feed a `pk__in` filter from a pk extracting subquery, which again works with _select_related_ or _prefetch_related_.

There is a simple perf test case showing the huge impact (>> 10x faster).

Fixes #193.