### PR TITLE
performance optimizations

### DIFF
--- a/computedfields/helpers.py
+++ b/computedfields/helpers.py
@@ -1,6 +1,7 @@
 from itertools import tee, zip_longest
 from django.db.models import Model, QuerySet
-from typing import Any, Iterator, List, Sequence, Type, TypeVar, Tuple, Union, Generator, Iterable
+from typing import (Any, Iterator, List, Sequence, Type, TypeVar, Tuple, Union,
+                    Generator, Iterable, Optional, FrozenSet)
 
 T = TypeVar('T', covariant=True)
 
@@ -88,3 +89,9 @@ def proxy_to_base_model(proxymodel: Type[Model]) -> Union[Type[Model], None]:
 
 def are_same(*args) -> bool:
     return len(set(args)) == 1
+
+
+def frozenset_none(data: Optional[Iterable[Any]]) -> Optional[FrozenSet[Any]]:
+    if data is None:
+        return
+    return frozenset(data)

--- a/computedfields/management/commands/checkdata.py
+++ b/computedfields/management/commands/checkdata.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
         for model in models:
             qs = model._base_manager.all()
             amount = qs.count()
-            fields = set(active_resolver.computed_models[model].keys())
+            fields = frozenset(active_resolver.computed_models[model].keys())
             qsize = active_resolver.get_querysize(model, fields, size)
             self.eprint(f'- {self.style.MIGRATE_LABEL(modelname(model))}')
             self.eprint(f'  Fields: {", ".join(fields)}')

--- a/computedfields/management/commands/updatedata.py
+++ b/computedfields/management/commands/updatedata.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
             model_name, desync = data.get('model'), data.get('desync')
             model: Type[Model] = cast(Type[Model], apps.get_model(model_name))
             amount = len(desync)
-            fields = set(active_resolver.computed_models[model].keys())
+            fields = frozenset(active_resolver.computed_models[model].keys())
             self.stdout.write(f'- {self.style.MIGRATE_LABEL(modelname(model))}')
             self.stdout.write(f'  Fields: {", ".join(fields)}')
             self.stdout.write(f'  Desync Records: {amount}')
@@ -120,7 +120,7 @@ class Command(BaseCommand):
         for model in models:
             qs = model._base_manager.all()
             amount = qs.count()
-            fields = set(active_resolver.computed_models[model].keys())
+            fields = frozenset(active_resolver.computed_models[model].keys())
             self.stdout.write(f'- {self.style.MIGRATE_LABEL(modelname(model))}')
             self.stdout.write(f'  Fields: {", ".join(fields)}')
             self.stdout.write(f'  Records: {amount}')
@@ -181,7 +181,7 @@ class Command(BaseCommand):
         for model in models:
             qs = model._base_manager.all()
             amount = qs.count()
-            fields = list(active_resolver.computed_models[model].keys())
+            fields = frozenset(active_resolver.computed_models[model].keys())
             qsize = active_resolver.get_querysize(model, fields, size)
             self.stdout.write(f'- {self.style.MIGRATE_LABEL(modelname(model))}')
             self.stdout.write(f'  Fields: {", ".join(fields)}')

--- a/computedfields/resolver.py
+++ b/computedfields/resolver.py
@@ -11,7 +11,7 @@ from django.db.models import QuerySet
 
 from .settings import settings
 from .graph import ComputedModelsGraph, ComputedFieldsException, Graph, ModelGraph, IM2mMap
-from .helpers import proxy_to_base_model, slice_iterator, subquery_pk, are_same
+from .helpers import proxy_to_base_model, slice_iterator, subquery_pk, are_same, frozenset_none
 from . import __version__
 from .signals import resolver_start, resolver_exit, resolver_update
 
@@ -19,7 +19,7 @@ from fast_update.fast import fast_update
 
 # typing imports
 from typing import (Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set,
-                    Tuple, Type, Union, cast, overload)
+                    Tuple, Type, Union, cast, overload, FrozenSet)
 from django.db.models import Field, Model
 from .graph import (IComputedField, IDepends, IFkMap, ILocalMroMap, ILookupMap, _ST, _GT, F,
                     IRecorded, IRecordedStrict, IModelUpdate, IModelUpdateCache)
@@ -91,8 +91,12 @@ class Resolver:
         self._initialized: bool = False   # initialized (computed_models populated)?
         self._map_loaded: bool = False    # final stage with fully loaded maps
 
-        # model update cache
-        self._updates_cache: IModelUpdateCache = defaultdict(dict)
+        # runtime caches
+        self._cached_updates: IModelUpdateCache = defaultdict(dict)
+        self._cached_mro = defaultdict(dict)
+        self._cached_select_related = defaultdict(dict)
+        self._cached_prefetch_related = defaultdict(dict)
+        self._cached_querysize = defaultdict(lambda: defaultdict(dict))
 
     def add_model(self, sender: Type[Model], **kwargs) -> None:
         """
@@ -236,7 +240,17 @@ class Resolver:
         self._m2m = self._graph._m2m
         self._patch_proxy_models()
         self._map_loaded = True
-        self._updates_cache = defaultdict(dict)
+        self._clear_runtime_caches()
+
+    def _clear_runtime_caches(self):
+        """
+        Clear all runtime caches.
+        """
+        self._cached_updates.clear()
+        self._cached_mro.clear()
+        self._cached_select_related.clear()
+        self._cached_prefetch_related.clear()
+        self._cached_querysize.clear()
 
     def _patch_proxy_models(self) -> None:
         """
@@ -258,7 +272,7 @@ class Resolver:
     def get_local_mro(
         self,
         model: Type[Model],
-        update_fields: Optional[Iterable[str]] = None
+        update_fields: Optional[FrozenSet[str]] = None
     ) -> List[str]:
         """
         Return `MRO` for local computed field methods for a given set of `update_fields`.
@@ -267,39 +281,44 @@ class Resolver:
 
         Returns computed fields as self dependent to simplify local field dependency calculation.
         """
-        # TODO: investigate - memoization of update_fields result? (runs ~4 times faster)
+        try:
+            return self._cached_mro[model][update_fields]
+        except KeyError:
+            pass
         entry = self._local_mro.get(model)
         if not entry:
+            self._cached_mro[model][update_fields] = []
             return []
         if update_fields is None:
+            self._cached_mro[model][update_fields] = entry['base']
             return entry['base']
-        update_fields = frozenset(update_fields)
         base = entry['base']
         fields = entry['fields']
         mro = 0
         for field in update_fields:
             mro |= fields.get(field, 0)
-        return [name for pos, name in enumerate(base) if mro & (1 << pos)]
+        result = [name for pos, name in enumerate(base) if mro & (1 << pos)]
+        self._cached_mro[model][update_fields] = result
+        return result
 
     def get_model_updates(
         self,
         model: Type[Model],
-        update_fields: Optional[Iterable[str]] = None
+        update_fields: Optional[FrozenSet[str]] = None
     ) -> IModelUpdate:
         """
         For a given model and updated fields this method
         returns a dictionary with dependent models (keys) and a tuple
         with dependent fields and the queryset accessor string (value).
         """
-        modeldata = self._map.get(model)
-        if not modeldata:
-            return {}
-        if not update_fields is None:
-            update_fields = frozenset(update_fields)
         try:
-            return self._updates_cache[model][update_fields]
+            return self._cached_updates[model][update_fields]
         except KeyError:
             pass
+        modeldata = self._map.get(model)
+        if not modeldata:
+            self._cached_updates[model][update_fields] = {}
+            return {}
         if not update_fields:
             updates: Set[str] = set(modeldata.keys())
         else:
@@ -316,7 +335,7 @@ class Resolver:
                 m_fields, m_paths = model_updates[m]
                 m_fields.update(fields)
                 m_paths.update(paths)
-        self._updates_cache[model][update_fields] = model_updates
+        self._cached_updates[model][update_fields] = model_updates
         return model_updates
 
     def _querysets_for_update(
@@ -331,7 +350,7 @@ class Resolver:
         queryset containing all dependent objects.
         """
         final: Dict[Type[Model], List[Any]] = {}
-        model_updates = self.get_model_updates(model, update_fields)
+        model_updates = self.get_model_updates(model, frozenset_none(update_fields))
         if not model_updates:
             return final
 
@@ -566,8 +585,8 @@ class Resolver:
             queryset = model._base_manager.filter(pk__in=subquery_pk(queryset, queryset.db))
 
         # correct update_fields by local mro
-        mro: List[str] = self.get_local_mro(model, update_fields)
-        fields = set(mro)
+        mro: List[str] = self.get_local_mro(model, frozenset_none(update_fields))
+        fields = frozenset(mro)
         if update_fields:
             update_fields.update(fields)
 
@@ -679,49 +698,65 @@ class Resolver:
                 stack.append((field, getattr(instance, field)))
                 setattr(instance, field, self._compute(instance, model, field))
 
-    # TODO: the following 3 lookups are very expensive at runtime adding ~2s for 1M calls
-    #       --> all need pregenerated lookup maps
-    # Note: the same goes for get_local_mro and _queryset_for_update...
     def get_select_related(
         self,
         model: Type[Model],
-        fields: Optional[Iterable[str]] = None
+        fields: Optional[FrozenSet[str]] = None
     ) -> Set[str]:
         """
         Get defined select_related rules for `fields` (all if none given).
         """
-        if fields is None:
-            fields = self._computed_models[model].keys()
+        try:
+            return self._cached_select_related[model][fields]
+        except KeyError:
+            pass
         select: Set[str] = set()
-        for field in fields:
+        ff = fields
+        if ff is None:
+            ff = frozenset(self._computed_models[model].keys())
+        for field in ff:
             select.update(self._computed_models[model][field]._computed['select_related'])
+        self._cached_select_related[model][fields] = select
         return select
 
     def get_prefetch_related(
         self,
         model: Type[Model],
-        fields: Optional[Iterable[str]] = None
+        fields: Optional[FrozenSet[str]] = None
     ) -> List:
         """
         Get defined prefetch_related rules for `fields` (all if none given).
         """
-        if fields is None:
-            fields = self._computed_models[model].keys()
+        try:
+            return self._cached_prefetch_related[model][fields]
+        except KeyError:
+            pass
         prefetch: List[Any] = []
-        for field in fields:
+        ff = fields
+        if ff is None:
+            ff = frozenset(self._computed_models[model].keys())
+        for field in ff:
             prefetch.extend(self._computed_models[model][field]._computed['prefetch_related'])
+        self._cached_prefetch_related[model][fields] = prefetch
         return prefetch
 
     def get_querysize(
         self,
         model: Type[Model],
-        fields: Optional[Iterable[str]] = None,
+        fields: Optional[FrozenSet[str]] = None,
         override: Optional[int] = None
     ) -> int:
+        try:
+            return self._cached_querysize[model][fields][override]
+        except KeyError:
+            pass
+        ff = fields
+        if ff is None:
+            ff = frozenset(self._computed_models[model].keys())
         base = settings.COMPUTEDFIELDS_QUERYSIZE if override is None else override
-        if fields is None:
-            fields = self._computed_models[model].keys()
-        return min(self._computed_models[model][f]._computed['querysize'] or base for f in fields)
+        result = min(self._computed_models[model][f]._computed['querysize'] or base for f in ff)
+        self._cached_querysize[model][fields][override] = result
+        return result
 
     def get_contributing_fks(self) -> IFkMap:
         """
@@ -994,7 +1029,7 @@ class Resolver:
         model = type(instance)
         if not self.has_computedfields(model):
             return update_fields
-        cf_mro = self.get_local_mro(model, update_fields)
+        cf_mro = self.get_local_mro(model, frozenset_none(update_fields))
         if update_fields:
             update_fields = set(update_fields)
             update_fields.update(set(cf_mro))
@@ -1150,7 +1185,7 @@ class NotComputed:
             # FIXME: untangle the side effect update of fields in update_dependent <-- bulk_updater
             fields = local_data['fields']
             if fields and active_resolver.has_computedfields(model):
-                fields = set(active_resolver.get_local_mro(model, local_data['fields']))
+                fields = set(active_resolver.get_local_mro(model, frozenset(fields)))
 
             mdata = active_resolver._querysets_for_update(
                 model,

--- a/example/test_full/tests/test_querysize.py
+++ b/example/test_full/tests/test_querysize.py
@@ -7,7 +7,7 @@ from computedfields.settings import settings as settings
 class TestQuerysize(TestCase):
     def test_default(self):
         self.assertEqual(
-            active_resolver.get_querysize(Querysize, ['default']),
+            active_resolver.get_querysize(Querysize, frozenset(['default'])),
             settings.COMPUTEDFIELDS_QUERYSIZE
         )
         self.assertEqual(
@@ -19,7 +19,7 @@ class TestQuerysize(TestCase):
     def test_default_altered(self):
         self.assertEqual(settings.COMPUTEDFIELDS_QUERYSIZE, 10000)
         self.assertEqual(
-            active_resolver.get_querysize(Querysize, ['default'], 10000),
+            active_resolver.get_querysize(Querysize, frozenset(['default']), 10000),
             settings.COMPUTEDFIELDS_QUERYSIZE
         )
 
@@ -28,22 +28,22 @@ class TestQuerysize(TestCase):
         self.assertEqual(active_resolver.get_querysize(Querysize), 1)
         self.assertEqual(active_resolver.get_querysize(Querysize, None, 10000), 1)
         # q10 limits
-        self.assertEqual(active_resolver.get_querysize(Querysize, ['default', 'q10']), 10)
-        self.assertEqual(active_resolver.get_querysize(Querysize, ['default', 'q10'], 10000), 10)
-        self.assertEqual(active_resolver.get_querysize(Querysize, ['default', 'q10', 'q100', 'q1000']), 10)
+        self.assertEqual(active_resolver.get_querysize(Querysize, frozenset(['default', 'q10'])), 10)
+        self.assertEqual(active_resolver.get_querysize(Querysize, frozenset(['default', 'q10']), 10000), 10)
+        self.assertEqual(active_resolver.get_querysize(Querysize, frozenset(['default', 'q10', 'q100', 'q1000'])), 10)
         # q100 limits
-        self.assertEqual(active_resolver.get_querysize(Querysize, ['default', 'q100']), 100)
-        self.assertEqual(active_resolver.get_querysize(Querysize, ['default', 'q100', 'q1000'], 10000), 100)
+        self.assertEqual(active_resolver.get_querysize(Querysize, frozenset(['default', 'q100'])), 100)
+        self.assertEqual(active_resolver.get_querysize(Querysize, frozenset(['default', 'q100', 'q1000']), 10000), 100)
         # q1000 limits
-        self.assertEqual(active_resolver.get_querysize(Querysize, ['default', 'q1000'], 10000), 1000)
+        self.assertEqual(active_resolver.get_querysize(Querysize, frozenset(['default', 'q1000']), 10000), 1000)
 
     def test_chain(self):
         # c_10_100 can do 100, but is limited by prev q10
-        mro = active_resolver.get_local_mro(Querysize, ['q10'])
-        self.assertEqual(active_resolver.get_querysize(Querysize, mro, 10000), 1)
+        mro = active_resolver.get_local_mro(Querysize, frozenset(['q10']))
+        self.assertEqual(active_resolver.get_querysize(Querysize, frozenset(mro), 10000), 1)
 
     def test_low_override_wins(self):
         # q1000 wins
-        self.assertEqual(active_resolver.get_querysize(Querysize, ['default', 'q1000'], 10000), 1000)
+        self.assertEqual(active_resolver.get_querysize(Querysize, frozenset(['default', 'q1000']), 10000), 1000)
         # override wins
-        self.assertEqual(active_resolver.get_querysize(Querysize, ['default', 'q1000'], 10), 10)
+        self.assertEqual(active_resolver.get_querysize(Querysize, frozenset(['default', 'q1000']), 10), 10)

--- a/example/test_full/tests/test_update_backend.py
+++ b/example/test_full/tests/test_update_backend.py
@@ -1,0 +1,84 @@
+from django.test import TestCase
+from ..models import EmailUser
+from computedfields.raw_update import merged_update
+from django.test.utils import CaptureQueriesContext
+from django.db import connection
+
+
+class TestRawUpdate(TestCase):
+    def test_mt_support(self):
+        eu1 = EmailUser.objects.create(forname='Anton', surname='AAA', email='aaa@example.com')
+        eu2 = EmailUser.objects.create(forname='Anton', surname='AAA', email='aaa@example.com')
+        eu3 = EmailUser.objects.create(forname='Anton', surname='AAA', email='aaa@example.com')
+        objs = [eu1, eu2, eu3]
+
+        # one merged update on emailuser
+        for o in objs:
+            o.email = 'ziggy@example.com'
+        with CaptureQueriesContext(connection) as queries:
+            merged_update(EmailUser.objects.all(), objs, ['email'])
+        self.assertEqual(len(queries.captured_queries), 1)
+        self.assertTrue(queries.captured_queries[0]['sql'].startswith('UPDATE "test_full_emailuser"'))
+        self.assertEqual(
+            list(EmailUser.objects.all().values_list('email', flat=True)),
+            ['ziggy@example.com'] * 3
+        )
+        
+        # one merged update on user
+        for o in objs:
+            o.forname = 'Ziggy'
+        with CaptureQueriesContext(connection) as queries:
+            merged_update(EmailUser.objects.all(), objs, ['forname'])
+        self.assertEqual(len(queries.captured_queries), 1)
+        self.assertTrue(queries.captured_queries[0]['sql'].startswith('UPDATE "test_full_user"'))
+        self.assertEqual(
+            list(EmailUser.objects.all().values_list('forname', flat=True)),
+            ['Ziggy'] * 3
+        )
+
+        # 2 updates (one merged, one single) on user
+        for o in objs:
+            o.surname = 'Zabalot'
+        objs[0].surname = 'ZZZ'
+        with CaptureQueriesContext(connection) as queries:
+            merged_update(EmailUser.objects.all(), objs, ['surname'])
+        self.assertEqual(len(queries.captured_queries), 2)
+        self.assertTrue(queries.captured_queries[0]['sql'].startswith('UPDATE "test_full_user"'))
+        self.assertTrue(queries.captured_queries[1]['sql'].startswith('UPDATE "test_full_user"'))
+        self.assertEqual(
+            list(EmailUser.objects.all().values_list('surname', flat=True).order_by('pk')),
+            ['ZZZ', 'Zabalot', 'Zabalot']
+        )
+
+        # 2 updates, one on emailuser, one on user
+        for o in objs:
+            o.email = 'xxx@example.com'
+            o.forname = 'AAA'
+        with CaptureQueriesContext(connection) as queries:
+            merged_update(EmailUser.objects.all(), objs, ['email', 'forname'])
+        self.assertEqual(len(queries.captured_queries), 2)
+        self.assertTrue(queries.captured_queries[0]['sql'].startswith('UPDATE "test_full_emailuser"'))
+        self.assertTrue(queries.captured_queries[1]['sql'].startswith('UPDATE "test_full_user"'))
+        self.assertEqual(
+            list(EmailUser.objects.all().values_list('email', flat=True)),
+            ['xxx@example.com'] * 3
+        )
+        self.assertEqual(
+            list(EmailUser.objects.all().values_list('forname', flat=True)),
+            ['AAA'] * 3
+        )
+
+        # works with one object
+        with CaptureQueriesContext(connection) as queries:
+            merged_update(EmailUser.objects.all(), [eu1], ['email'])
+        self.assertEqual(len(queries.captured_queries), 1)
+        self.assertTrue(queries.captured_queries[0]['sql'].startswith('UPDATE "test_full_emailuser"'))
+
+        # does not merge 2 objects
+        with CaptureQueriesContext(connection) as queries:
+            merged_update(EmailUser.objects.all(), [eu1, eu2], ['email', 'forname', 'surname'])
+        self.assertEqual(len(queries.captured_queries), 4)
+        self.assertTrue(queries.captured_queries[0]['sql'].startswith('UPDATE "test_full_emailuser"'))
+        self.assertTrue(queries.captured_queries[1]['sql'].startswith('UPDATE "test_full_emailuser"'))
+        self.assertTrue(queries.captured_queries[2]['sql'].startswith('UPDATE "test_full_user"'))
+        self.assertTrue(queries.captured_queries[3]['sql'].startswith('UPDATE "test_full_user"'))


### PR DESCRIPTION
#196 revealed several performance smells, that shall be ocevered here:
- [ ] runtime caches
- [ ] discourage _bulk_update_
  - [ ] new update imps: _merge_update_ & _flat_update_
  - [ ] integrate new impls with _fast_update_ package
  - [ ] BREAKING: revamp settings.py variables as layouted here https://github.com/netzkolchose/django-computedfields/issues/196#issuecomment-3139633838

Since this changes the way data gets updated by the resolver, we have to release a new beta for it.