### PR TITLE
[Fix] Fix field merging logic in resolver.py

### DIFF
--- a/computedfields/resolver.py
+++ b/computedfields/resolver.py
@@ -1174,7 +1174,7 @@ class NotComputed:
                 if local_entry['fields'] is None:
                     final_entry['fields'] = set(active_resolver.get_local_mro(model))
                 else:
-                    final_entry['fields'] |= final_entry['fields']
+                    final_entry['fields'] |= local_entry['fields']
                 final_entry['pks'] |= local_entry['pks']
                 local_entry['pks'].clear()
 


### PR DESCRIPTION
Hi @jerch, 

I'd say there is a bug in the resync function of the NotComputed class. I think pks from the local entries are correctly merged, but not the update fields.

This can be reproduced by modifying in a computed model a standard field and a m2m, and saving with update fields set. The computed fields that depends on the m2m overwrite the fields that depends on the update fields array that we passed and, thus, some computed fields are not recomputed.